### PR TITLE
Remove webrtc adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ clients to communicate directly with each other.
 
 * Works __seamlessly__ with [Signal-Fire Server](https://github.com/Signal-Fire/server)
 * __Abstracts away__ the hassles of setting up peer connections
-* Includes [webrtc-adapter](https://github.com/webrtchacks/adapter) for browser compatibility
 * Uses a __simple__, JSON-based [protocol](https://github.com/Signal-Fire/server/blob/main/PROTOCOL.md)
 * __No__ forest of dependencies
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,28 +8,6 @@
       "version": "3.1.22",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.22.tgz",
       "integrity": "sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ=="
-    },
-    "rtcpeerconnection-shim": {
-      "version": "1.2.15",
-      "resolved": "https://registry.npmjs.org/rtcpeerconnection-shim/-/rtcpeerconnection-shim-1.2.15.tgz",
-      "integrity": "sha512-C6DxhXt7bssQ1nHb154lqeL0SXz5Dx4RczXZu2Aa/L1NJFnEVDxFwCBo3fqtuljhHIGceg5JKBV4XJ0gW5JKyw==",
-      "requires": {
-        "sdp": "^2.6.0"
-      }
-    },
-    "sdp": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/sdp/-/sdp-2.12.0.tgz",
-      "integrity": "sha512-jhXqQAQVM+8Xj5EjJGVweuEzgtGWb3tmEEpl3CLP3cStInSbVHSg0QWOGQzNq8pSID4JkpeV2mPqlMDLrm0/Vw=="
-    },
-    "webrtc-adapter": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-7.7.1.tgz",
-      "integrity": "sha512-TbrbBmiQBL9n0/5bvDdORc6ZfRY/Z7JnEj+EYOD1ghseZdpJ+nF2yx14k3LgQKc7JZnG7HAcL+zHnY25So9d7A==",
-      "requires": {
-        "rtcpeerconnection-shim": "^1.2.15",
-        "sdp": "^2.12.0"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "nanoid": "^3.1.22",
-    "webrtc-adapter": "^7.7.1"
+    "nanoid": "^3.1.22"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 'use strict'
 
-import adapter from 'webrtc-adapter'
 import Client, { IncomingMessage } from './lib/Client'
 import IncomingSession from './lib/IncomingSession'
 import PeerConnection from './lib/PeerConnection'
@@ -105,7 +104,3 @@ export { default as Client, Message, OutgoingMessage, IncomingMessage } from './
 export { default as PeerConnection } from './lib/PeerConnection'
 export { default as IncomingSession } from './lib/IncomingSession'
 export { default as OutgoingSession } from './lib/OutgoingSession'
-
-// Hack to make sure the adapter import is not removed
-// by the TypeScript compiler
-export const browserVersion = adapter.browserDetails.version


### PR DESCRIPTION
The necessity of webrtc-adapter today is uncertain. Users can add webrtc-adapter themselves as required, this should not bog down the module.

Also upgrades dependency nanoid.